### PR TITLE
[#8] [ドキュメント] Docker周りのバージョンを変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Template files when building a Go development environment with docker.
 
 ```bash
 > docker --version
-Docker version 19.03.12, build 48a66213fe
+Docker version 20.10.8, build 3967b7d
 
 > docker-compose --version
-docker-compose version 1.27.2, build 18f557f9
+docker-compose version 1.29.2, build 5becea4c
 ```
   
 ## Build (docker-compose build)


### PR DESCRIPTION
# issue
#8 

# やったこと
- Docker周りのバージョンの記載を変更

# 備考
本PR は macOS を Catalina から Big Sur にアップデートしたことによって、Dockerのアップデートを行う必要があった