### PR TITLE
[#4] go mod download の実行タイミングの変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM golang:1.16-alpine
+FROM golang:1.17-alpine
 WORKDIR /go/src
 
 COPY ./ ./
-# TODO[#4]: 依存関係が無い時にgo mod downloadしても回避できるようにする
-# RUN go mod download
 RUN apk add --no-cache gcc musl-dev

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ dc-build:
 	./setup/go_mod_init.sh
 	docker-compose up --build -d
 run:
+	docker-compose exec app go mod download
 	docker-compose exec app go run main.go
 test:
 	docker-compose exec app go test ./... -v


### PR DESCRIPTION
# issue
#4 

# やったこと
- go mod download の実行タイミングを go run main.go の前に変更
- （ついてでgoのバージョンを1.17にした）