### PR TITLE
[#2] README.mdのDockerの項目の段落を一つ下げる

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
   
 Template files when building a Go development environment with docker.  
   
-## Version
 
+## Docker
+  
+### Version
+  
 ```bash
 > docker --version
 Docker version 20.10.8, build 3967b7d
@@ -12,19 +15,19 @@ Docker version 20.10.8, build 3967b7d
 docker-compose version 1.29.2, build 5becea4c
 ```
   
-## Build (docker-compose build)
+### Build (docker-compose build)
   
 ```bash
 > make dc-build
 ```
   
-## Run
+### Run
   
 ```bash
 > make run
 ```
   
-## Tests
+### Tests
   
 ```bash
 > make test


### PR DESCRIPTION
# issue
#2 

# やったこと
- README.mdのDockerの項目の段落を一つ下げる
  - プロジェクトを新規で作成する際に、Usage と Docker を同じ段落にするため