### PR TITLE
[#12] go.mod に記述される Go のバージョンをホストの環境ではなく、Docker内の環境のものになるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 dc-build:
-	./setup/go_mod_init.sh
 	docker-compose up --build -d
+	docker-compose exec app sh ./setup/go_mod_init.sh
 run:
 	docker-compose exec app go mod download
 	docker-compose exec app go run main.go


### PR DESCRIPTION
# issue
#12

# やったこと
- go.mod に記述される Go のバージョンをホストの環境ではなく、Docker内の環境のものになるようにした
  - go mod init の実行者をホストではなく、コンテナにした